### PR TITLE
Add R2 bucket for firmware hosting

### DIFF
--- a/firmware_hosting/bucket.tf
+++ b/firmware_hosting/bucket.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_r2_bucket" "bucket" {
+  name       = var.bucket_name
+  account_id = var.cloudflare_account_id
+}

--- a/firmware_hosting/github-access.tf
+++ b/firmware_hosting/github-access.tf
@@ -1,0 +1,24 @@
+data "cloudflare_api_token_permission_groups" "all" {}
+
+resource "cloudflare_api_token" "github-token" {
+  name = "github-firmware-upload-token"
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.r2["Workers R2 Storage Bucket Item Read"],
+      data.cloudflare_api_token_permission_groups.all.r2["Workers R2 Storage Bucket Item Write"]
+    ]
+    resources = {
+      "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_${var.bucket_name}" = "*"
+    }
+  }
+}
+
+resource "github_actions_organization_secret" "cloudflare-r2-upload-token" {
+  secret_name     = "CLOUDFLARE_R2_UPLOAD_TOKEN"
+  visibility      = "selected"
+  plaintext_value = cloudflare_api_token.github-token.value
+
+  lifecycle {
+    ignore_changes = [selected_repository_ids]
+  }
+}

--- a/firmware_hosting/main.tf
+++ b/firmware_hosting/main.tf
@@ -12,5 +12,9 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 4"
     }
+    github = {
+      source  = "integrations/github"
+      version = "6.2.3"
+    }
   }
 }

--- a/firmware_hosting/main.tf
+++ b/firmware_hosting/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  cloud {
+    organization = "esphome"
+
+    workspaces {
+      name = "firmware_hosting"
+    }
+  }
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4"
+    }
+  }
+}

--- a/firmware_hosting/variables.tf
+++ b/firmware_hosting/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "The name of the R2 bucket"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "The account ID for the bucket"
+  type        = string
+}

--- a/firmware_hosting/variables.tf
+++ b/firmware_hosting/variables.tf
@@ -7,3 +7,9 @@ variable "cloudflare_account_id" {
   description = "The account ID for the bucket"
   type        = string
 }
+
+variable "github_organization" {
+  description = "The GitHub organization to create the secret in"
+  type        = string
+  default     = "esphome"
+}


### PR DESCRIPTION
- Add bucket for hosting
- Provision cloudflare API token that has access to upload files to bucket
- Save API token to GitHub organisation secrets for use in workflows